### PR TITLE
Added ability to pass in request via $_GET['r'].

### DIFF
--- a/core/slirrequest.class.php
+++ b/core/slirrequest.class.php
@@ -334,8 +334,10 @@ class SLIRRequest
   {
     $params = array();
 
-    // The parameters should be the first set of characters after the SLIR path
-    $request    = preg_replace('`.*?/' . preg_quote(basename(SLIRConfig::$pathToSLIR)) . '/`', '', (string) $_SERVER['REQUEST_URI'], 1);
+    // You can pass in the parameters via $_GET['r']. Otherwise, the parameters should be the first set of characters after the SLIR path
+    $request = (isset($_GET['r']))
+      ? $_GET['r']
+      : preg_replace('`.*?/' . preg_quote(basename(SLIRConfig::$pathToSLIR)) . '/`', '', (string) $_SERVER['REQUEST_URI'], 1);
     $paramString  = strtok($request, '/');
 
     if ($paramString === false || $paramString === $request) {


### PR DESCRIPTION
Adds ability to obfuscate the SLIR directory via external rewrites, and
optionally keeps parameters identical even when htaccess isn't
available.

These are now functionally identical:

`/slir/w100/image.jpg`
`/slir/?r=w100/image.jpg`

And the following rewrite rule is now possible:

`RewriteRule ^resize(.*)$ /some/buried/directory/slir/index.php?r=$1 [QSA,L]`
