### PR TITLE
Support for external document root

### DIFF
--- a/core/slir.class.php
+++ b/core/slir.class.php
@@ -979,13 +979,30 @@ class SLIR
       return false;
     }
 
-    $imageModified  = filectime($this->getRequest()->fullPath());
+	// if path is valid url try to get Last-Modified
+	if ($this->isValidURL($this->getRequest()->fullPath())) {
+		try {
+			$headers= @get_headers($this->getRequest()->fullPath(),1);
+			$imageModified=@strtotime($header['Last-Modified']);
+		} catch (Exception $e) {
+			// couldn't get Last-Modified or error in parsing
+			// so assume image is not cached
+			return false;
+		}
+	} else {
+		$imageModified  = filectime($this->getRequest()->fullPath());
+	}
 
     if ($imageModified >= $cacheModified) {
       return false;
     } else {
       return true;
     }
+  }
+
+  function isValidURL($url)
+  {
+    return preg_match('|^http(s)?://[a-z0-9-]+(.[a-z0-9-]+)*(:[0-9]+)?(/.*)?$|i', $url);
   }
 
   /**

--- a/core/slirrequest.class.php
+++ b/core/slirrequest.class.php
@@ -416,8 +416,8 @@ Example usage:
       if (SLIRConfig::$defaultImagePath !== null && !$this->isUsingDefaultImagePath()) {
         $this->isUsingDefaultImagePath  = true;
         return $this->setPath(SLIRConfig::$defaultImagePath);
-      } else {
-        throw new RuntimeException('Image does not exist: ' . $this->fullPath());
+      } else if (SLIRConfig::$documentRoot === null || !@fopen($this->fullPath(),'r')){
+		throw new RuntimeException('Image does not exist: ' . $this->fullPath());
       }
     }
   }


### PR DESCRIPTION
This code change allows usage of external document roots (like http://example.com). The existence of the file and the last modified date are requested correctly with these changes.