### PR TITLE
Added check for headers already being sent in header function

### DIFF
--- a/core/slir.class.php
+++ b/core/slir.class.php
@@ -1295,7 +1295,7 @@ class SLIR
   {
     $this->headers[] = $header;
 
-    if (!$this->isCLI()) {
+    if (!$this->isCLI() && !headers_sent()) {
       header($header);
     }
 


### PR DESCRIPTION
Simply checks if the headers have already been sent before trying to send any additional headers. See issue https://github.com/lencioni/SLIR/issues/7 for more details about generated errors.
