### PR TITLE
implement sharpening toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ To use SLIR, place an `<img\>` tag with the `src` attribute pointing to the path
       <td>Progressive</td>
       <td><code>/slir/<strong>p1</strong>/path/to/image.jpg</code></td>
     </tr>
+    <tr>
+      <td><var>s</var></td>
+      <td>Sharpen</td>
+      <td><code>/slir/<strong>s0</strong>/path/to/image.jpg</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/core/libs/slirimage.class.php
+++ b/core/libs/slirimage.class.php
@@ -32,6 +32,11 @@ abstract class SLIRImage
   protected $progressive;
 
   /**
+   * @var boolean
+   */
+  protected $sharpen;
+
+  /**
    * @var string specified cropper to use
    */
   protected $cropper;
@@ -103,6 +108,7 @@ abstract class SLIRImage
       $this->getBackground(),
       $this->getSharpeningFactor(),
       $this->getProgressive(),
+      $this->getSharpen(),
       $this->getInfo(),
       $this->getCropper(),
       $this->getQuality()
@@ -223,6 +229,25 @@ abstract class SLIRImage
     return $this;
   }
 
+    /**
+   * @return boolean
+   * @since 2.0
+   */
+  public function getSharpen()
+  {
+    return $this->sharpen;
+  }
+
+  /**
+   * @param boolean $sharpen
+   * @return SLIRImageLibrary
+   */
+  public function setSharpen($sharpen)
+  {
+    $this->sharpen = $sharpen;
+    return $this;
+  }
+
   /**
    * Sets the sharpening factor of the image
    * @param float $sharpeningFactor
@@ -329,7 +354,7 @@ abstract class SLIRImage
    */
   final protected function isSharpeningDesired()
   {
-    if ($this->isJPEG()) {
+    if ($this->isJPEG() && $this->getSharpen()) {
       return true;
     } else {
       return false;

--- a/core/libs/slirimagelib.interface.php
+++ b/core/libs/slirimagelib.interface.php
@@ -285,6 +285,18 @@ interface SLIRImageLibrary
   public function setProgressive($progressive);
 
   /**
+   * @return boolean
+   * @since 2.0
+   */
+  public function getSharpen();
+
+  /**
+   * @param boolean $sharpen
+   * @return SLIRImageLibrary
+   */
+  public function setSharpen($sharpen);
+
+  /**
    * Turns interlacing on or off
    * @return SLIRImageLibrary
    * @since 2.0

--- a/core/slir.class.php
+++ b/core/slir.class.php
@@ -61,6 +61,7 @@
  *     - Quality = q
  *     - Background fill color = b
  *     - Progressive = p
+ *     - Sharpen = s
  *
  * Note: filenames that include special characters must be URL-encoded (e.g.
  * plus sign, +, should be encoded as %2B) in order for SLIR to recognize them
@@ -406,6 +407,7 @@ class SLIR
         ->setBackground($this->getBackground())
         ->setQuality($this->getQuality())
         ->setProgressive($this->getProgressive())
+        ->setSharpen($this->getSharpen())
         ->setMimeType($this->getMimeType())
         ->setCropper($this->getRequest()->cropper);
 
@@ -822,6 +824,18 @@ class SLIR
     } else {
       return false;
     }
+  }
+
+  /**
+   * Determine whether the rendered image should be sharpened or not
+   * @return boolean
+   * @since 2.0
+   */
+  private function getSharpen()
+  {
+    return ($this->getRequest()->sharpen !== null)
+      ? $this->getRequest()->sharpen
+      : SLIRConfig::$defaultSharpen;
   }
 
   /**

--- a/core/slirconfigdefaults.class.php
+++ b/core/slirconfigdefaults.class.php
@@ -69,6 +69,15 @@ class SLIRConfigDefaults
    */
   public static $defaultProgressiveJPEG = true;
 
+
+  /**
+   * Default setting for whether images should be sharpened or not.
+   *
+   * @since 2.0
+   * @var boolean
+   */
+  public static $defaultSharpen = true;
+
   /**
    * How long (in seconds) the web browser should use its cached copy of the image
    * before checking with the server for a new version

--- a/core/slirrequest.class.php
+++ b/core/slirrequest.class.php
@@ -102,6 +102,13 @@ class SLIRRequest
   private $progressive;
 
   /**
+   * Whether or not to sharpen image
+   * @var boolean
+   * @since 2.0
+   */
+  private $sharpen;
+
+  /**
    * Color to fill background of transparent PNGs and GIFs
    * @var string
    * @since 2.0
@@ -159,6 +166,7 @@ class SLIRRequest
     unset($this->cropper);
     unset($this->quality);
     unset($this->progressive);
+    unset($this->sharpen);
     unset($this->background);
     unset($this->isUsingDefaultImagePath);
   }
@@ -195,6 +203,12 @@ class SLIRRequest
       case 'p':
       case 'progressive':
         $this->setProgressive($value);
+          break;
+
+      case 's';
+      case 'sharpen':
+      case 'sharpening':
+        $this->setSharpen($value);
           break;
 
       case 'b';
@@ -262,6 +276,15 @@ class SLIRRequest
   private function setProgressive($value)
   {
     $this->progressive  = (bool) $value;
+  }
+
+  /**
+   * @since 2.0
+   * @return void
+   */
+  private function setSharpen($value)
+  {
+    $this->sharpen  = (bool) $value;
   }
 
   /**
@@ -355,6 +378,7 @@ Available parameters:
  q = Quality (0-100)
  b = Background fill color (RRGGBB or RGB)
  p = Progressive (0 or 1)
+ s = Sharpen (0 or 1)
 
 Example usage:
 /slir/w300-h300-c1.1/path/to/image.jpg');
@@ -389,7 +413,7 @@ Example usage:
   {
     if (SLIRConfig::$forceQueryString === true) {
       return true;
-    } else if (!empty($_SERVER['QUERY_STRING']) && count(array_intersect(array('i', 'w', 'h', 'q', 'c', 'b', 'p'), array_keys($_GET)))) {
+    } else if (!empty($_SERVER['QUERY_STRING']) && count(array_intersect(array('i', 'w', 'h', 'q', 'c', 'b', 's', 'p'), array_keys($_GET)))) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
Closes #36

Implemented based on progressive (the `p` flag). I have more or less mimicked everything done with the progressive flag. The new sharpen flag is pulled into effect in `isSharpeningDesired()`. Basically, `isSharpeningDesired()` will return `false` if sharpening is turned off using `s0` in the URL.

All the functions have `@since 2.0` in the documentation (since I just copied from progressive), let me know if you want the number changed.
